### PR TITLE
Removed --force from DumpCommand

### DIFF
--- a/Command/DumpCommand.php
+++ b/Command/DumpCommand.php
@@ -37,12 +37,6 @@ class DumpCommand extends ContainerAwareCommand
                 InputOption::VALUE_REQUIRED,
                 "The folder path where the .sql file will be saved. Defaults to '%kernel.root%/var/db_backups/'.",
                 null
-            )
-            ->addOption(
-                'force',
-                null,
-                InputOption::VALUE_NONE,
-                'Suppresses prompt asking whether to continue.'
             );
     }
 
@@ -87,7 +81,7 @@ class DumpCommand extends ContainerAwareCommand
             return 1;
         }
 
-        if (!$input->getOption('force'))
+        if (!$input->getOption('no-interaction'))
         {
             $output->writeln('');
             $question = new ConfirmationQuestion('<question>Would you like to start the backup now? [Yn]</question>', true);


### PR DESCRIPTION
We should stick to the standard Symfony way of using suppressing any interactive questions which is done through the default --no-interaction|-n option that is available to all commands.

From the CLI help it does exactly the same as --force did previously.

``` bash
$ sf becklyn:db:dump --help
...
...
 --no-interaction (-n) Do not ask any interactive question
...
```
