### PR TITLE
Fixed typo in parameter docs for --path options

### DIFF
--- a/Command/DumpCommand.php
+++ b/Command/DumpCommand.php
@@ -35,7 +35,7 @@ class DumpCommand extends ContainerAwareCommand
                 'path',
                 'p',
                 InputOption::VALUE_REQUIRED,
-                "The folder path where the .sql file will be saved. Defaults to '%kernel.root%/var/db_backups/'.",
+                "The folder path where the .sql file will be saved. Defaults to '%kernel.root_dir%/var/db_backups/'.",
                 null
             )
             ->addOption(


### PR DESCRIPTION
Renamed the default path in description from %kernel.root% to %kernel.root_dir%
