### PR TITLE
Added support for multiple database types

### DIFF
--- a/BecklynDatabaseDumpBundle.php
+++ b/BecklynDatabaseDumpBundle.php
@@ -2,11 +2,21 @@
 
 namespace Becklyn\DatabaseDumpBundle;
 
+use Becklyn\DatabaseDUmpBundle\Service\DatabaseDumpServiceCompilerPass;
 use Becklyn\DatabaseDumpBundle\DependencyInjection\BecklynDatabaseDumpExtension;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\HttpKernel\Bundle\Bundle;
 
 class BecklynDatabaseDumpBundle extends Bundle
 {
+    public function build (ContainerBuilder $container)
+    {
+        parent::build($container);
+
+        $container->addCompilerPass(new DatabaseDumpServiceCompilerPass());
+    }
+
+
     public function getContainerExtension ()
     {
         return new BecklynDatabaseDumpExtension();

--- a/Command/DumpCommand.php
+++ b/Command/DumpCommand.php
@@ -3,7 +3,7 @@
 namespace Becklyn\DatabaseDumpBundle\Command;
 
 use Becklyn\DatabaseDumpBundle\Entity\DatabaseConnection;
-use Becklyn\DatabaseDumpBundle\Exception\MysqlDumpException;
+use Becklyn\DatabaseDumpBundle\Exception\DatabaseDumpException;
 use Becklyn\DatabaseDumpBundle\Service\DatabaseDumpService;
 use Symfony\Bundle\FrameworkBundle\Command\ContainerAwareCommand;
 use Symfony\Component\Console\Helper\FormatterHelper;
@@ -135,7 +135,7 @@ class DumpCommand extends ContainerAwareCommand
                     $output->writeln(preg_replace("~^(.*?)$~m", "    \\1", $dumpResult['error']));
                 }
             }
-            catch (MysqlDumpException $e)
+            catch (DatabaseDumpException $e)
             {
                 $output->writeln('<error>failed</error>');
                 $this->printDumpException($output, $e);
@@ -204,10 +204,10 @@ class DumpCommand extends ContainerAwareCommand
     /**
      * Prints an error box to the UI for the given exception
      *
-     * @param OutputInterface    $output
-     * @param MysqlDumpException $e
+     * @param OutputInterface       $output
+     * @param DatabaseDumpException $e
      */
-    protected function printDumpException (OutputInterface $output, MysqlDumpException $e)
+    protected function printDumpException (OutputInterface $output, DatabaseDumpException $e)
     {
         $error = $this->getHelper('formatter')->formatBlock(['', '  An error occurred during backup creation:  ', "  {$e->getMessage()}  ", ''], 'error');
         $output->writeln("\n$error\n");

--- a/DependencyInjection/BecklynDatabaseDumpExtension.php
+++ b/DependencyInjection/BecklynDatabaseDumpExtension.php
@@ -27,5 +27,6 @@ class BecklynDatabaseDumpExtension extends Extension
         $definition = $container->getDefinition('becklyn.db_dump.configuration');
         $definition->replaceArgument(1, $config['connections']);
         $definition->replaceArgument(2, $config['directory']);
+        $definition->replaceArgument(3, $config['dumper']);
     }
 }

--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -27,6 +27,11 @@ class Configuration implements ConfigurationInterface
                 ->scalarNode('directory')
                     ->defaultValue('%kernel.root_dir%/var/db_backups/')
                 ->end()
+                ->arrayNode('dumper')
+                    ->prototype('array')
+                        ->prototype('scalar')->end()
+                    ->end()
+                ->end()
             ->end();
 
         return $treeBuilder;

--- a/Entity/DatabaseConnection.php
+++ b/Entity/DatabaseConnection.php
@@ -9,9 +9,19 @@ use Doctrine\DBAL\Connection;
 class DatabaseConnection
 {
     /**
-     * @var int Type identifier for MySQL databases
+     * @var string Type identifier for MySQL databases
      */
-    const TYPE_MYSQL = 0;
+    const TYPE_MYSQL = 'mysql';
+
+    /**
+     * @var string Type identifier for PostgreSQL databases
+     */
+    const TYPE_POSTGRESQL = 'pgsql';
+
+    /**
+     * @var string Type identifier for SQLite databases
+     */
+    const TYPE_SQLITE = 'sqlite';
 
 
     /**
@@ -51,7 +61,7 @@ class DatabaseConnection
 
 
     /**
-     * @var int
+     * @var string
      */
     private $type;
 
@@ -60,7 +70,6 @@ class DatabaseConnection
      * @var string
      */
     private $backupPath;
-
 
 
     /**
@@ -72,10 +81,7 @@ class DatabaseConnection
     public function __construct ($identifier, Connection $connection = null)
     {
         $this->identifier = $identifier;
-
-        // So far we're only dealing with MySQL connections. In the future we need
-        // a proper way of detecting how to identify the connection's database type (aka the driver)
-        $this->type = self::TYPE_MYSQL;
+        $this->type       = $this->getDatabaseConnectionType($connection);
 
         if (!is_null($connection))
         {
@@ -87,6 +93,33 @@ class DatabaseConnection
         }
     }
 
+
+    /**
+     * Determines the type of the given Symfony2 Connection and maps it to DatabaseConnection types
+     *
+     * @param Connection $connection
+     *
+     * @return string|null
+     */
+    protected function getDatabaseConnectionType (Connection $connection)
+    {
+        $connectionParams = $connection->getParams();
+
+        switch ($connectionParams['driver'])
+        {
+            case 'pdo_mysql':
+                return DatabaseConnection::TYPE_MYSQL;
+
+            case 'pdo_pgsql':
+                return DatabaseConnection::TYPE_POSTGRESQL;
+
+            case 'sqlite':
+                return DatabaseConnection::TYPE_SQLITE;
+
+            default:
+                return null;
+        }
+    }
 
 
     /**
@@ -198,7 +231,7 @@ class DatabaseConnection
 
 
     /**
-     * @return int
+     * @return string
      */
     public function getType ()
     {
@@ -207,7 +240,7 @@ class DatabaseConnection
 
 
     /**
-     * @param int $type
+     * @param string $type
      */
     public function setType ($type)
     {

--- a/Entity/DatabaseConnection.php
+++ b/Entity/DatabaseConnection.php
@@ -9,6 +9,11 @@ use Doctrine\DBAL\Connection;
 class DatabaseConnection
 {
     /**
+     * @var string Used as fallback if the database type couldn't be identified
+     */
+    const TYPE_UNKNOWN = 'unknown';
+
+    /**
      * @var string Type identifier for MySQL databases
      */
     const TYPE_MYSQL = 'mysql';
@@ -103,6 +108,11 @@ class DatabaseConnection
      */
     protected function getDatabaseConnectionType (Connection $connection)
     {
+        if (is_null($connection))
+        {
+            return DatabaseConnection::TYPE_UNKNOWN;
+        }
+
         $connectionParams = $connection->getParams();
 
         switch ($connectionParams['driver'])
@@ -117,7 +127,7 @@ class DatabaseConnection
                 return DatabaseConnection::TYPE_SQLITE;
 
             default:
-                return null;
+                return DatabaseConnection::TYPE_UNKNOWN;
         }
     }
 

--- a/Exception/BackupDeletionException.php
+++ b/Exception/BackupDeletionException.php
@@ -4,6 +4,6 @@
 namespace Becklyn\DatabaseDumpBundle\Exception;
 
 
-class BackupDeletionException extends MysqlDumpException
+class BackupDeletionException extends DatabaseDumpException
 {
 }

--- a/Exception/DatabaseDumpException.php
+++ b/Exception/DatabaseDumpException.php
@@ -4,6 +4,6 @@
 namespace Becklyn\DatabaseDumpBundle\Exception;
 
 
-class MysqlDumpException extends \Exception
+class DatabaseDumpException extends \Exception
 {
 }

--- a/Exception/DirectoryCreationException.php
+++ b/Exception/DirectoryCreationException.php
@@ -4,6 +4,6 @@
 namespace Becklyn\DatabaseDumpBundle\Exception;
 
 
-class DirectoryCreationException extends MysqlDumpException
+class DirectoryCreationException extends DatabaseDumpException
 {
 }

--- a/Exception/InvalidConnectionException.php
+++ b/Exception/InvalidConnectionException.php
@@ -4,6 +4,6 @@
 namespace Becklyn\DatabaseDumpBundle\Exception;
 
 
-class InvalidConnectionException extends MysqlDumpException
+class InvalidConnectionException extends DatabaseDumpException
 {
 }

--- a/Exception/InvalidConnectionTypeException.php
+++ b/Exception/InvalidConnectionTypeException.php
@@ -4,6 +4,6 @@
 namespace Becklyn\DatabaseDumpBundle\Exception;
 
 
-class InvalidConnectionTypeException extends MysqlDumpException
+class InvalidConnectionTypeException extends DatabaseDumpException
 {
 }

--- a/Exception/NoDatabaseDumpersRegisteredException.php
+++ b/Exception/NoDatabaseDumpersRegisteredException.php
@@ -1,0 +1,9 @@
+<?php
+
+
+namespace Becklyn\DatabaseDumpBundle\Exception;
+
+
+class NoDatabaseDumpersRegisteredException extends DatabaseDumpException
+{
+}

--- a/Exception/NullConnectionException.php
+++ b/Exception/NullConnectionException.php
@@ -4,6 +4,6 @@
 namespace Becklyn\DatabaseDumpBundle\Exception;
 
 
-class NullConnectionException extends MysqlDumpException
+class NullConnectionException extends DatabaseDumpException
 {
 }

--- a/Resources/config/services.yml
+++ b/Resources/config/services.yml
@@ -8,6 +8,4 @@ services:
             - null
 
     becklyn.db_dump.dump:
-        class: Becklyn\DatabaseDumpBundle\Service\MysqlDumpService
-        arguments:
-            - @service_container
+        class: Becklyn\DatabaseDumpBundle\Service\DatabaseDumpService

--- a/Resources/config/services.yml
+++ b/Resources/config/services.yml
@@ -5,6 +5,7 @@ services:
             - @doctrine
             - null
             - null
+            - null
 
     becklyn.db_dump.dump:
         class: Becklyn\DatabaseDumpBundle\Service\MysqlDumpService

--- a/Service/BaseDatabaseDumpService.php
+++ b/Service/BaseDatabaseDumpService.php
@@ -77,14 +77,15 @@ abstract class BaseDatabaseDumpService
      * Retrieves the config value by key
      *
      * @param string $key
+     * @param mixed  $defaultValue
      *
      * @return mixed|null
      */
-    protected function getConfigValue ($key)
+    protected function getConfigValue ($key, $defaultValue = null)
     {
         if (!isset($this->config[$key]))
         {
-            return null;
+            return $defaultValue;
         }
 
         return $this->config[$key];

--- a/Service/BaseDatabaseDumpService.php
+++ b/Service/BaseDatabaseDumpService.php
@@ -1,0 +1,92 @@
+<?php
+
+
+namespace Becklyn\DatabaseDumpBundle\Service;
+
+
+use Becklyn\DatabaseDumpBundle\Entity\DatabaseConnection;
+
+abstract class BaseDatabaseDumpService
+{
+    /**
+     * @var array
+     */
+    protected $config;
+
+
+    /**
+     * MysqlDumpService constructor.
+     *
+     * @param DatabaseConfigurationService $configurationService
+     */
+    public function __construct (DatabaseConfigurationService $configurationService)
+    {
+        $this->config = $configurationService->getDumpServiceConfiguration($this->getIdentifier());
+    }
+
+
+    /**
+     * Returns a unique identifier for this DatabaseDumpService implementation
+     * which will also be used inside the config.yml to specifically configure
+     * this service
+     *
+     * @return string
+     */
+    public abstract function getIdentifier ();
+
+    /**
+     * Performs the actual backup operation for the given MySQL DatabaseConnection
+     *
+     * @param DatabaseConnection $connection
+     *
+     * @return array
+     */
+    public abstract function dump (DatabaseConnection $connection);
+
+
+    /**
+     * Sets or updates, if necessary, the backup file path for the given connection
+     *
+     * @param DatabaseConnection $connection
+     * @param string             $backupPath
+     */
+    public abstract function configureBackupPath (DatabaseConnection $connection, $backupPath);
+
+
+    /**
+     * Determines whether or not this DatabaseDumpService can backup the given DatabaseConnection
+     *
+     * @param DatabaseConnection $connection
+     *
+     * @return bool
+     */
+    public abstract function canHandle (DatabaseConnection $connection);
+
+
+    /**
+     * Determines whether the given connection is valid
+     *
+     * @param DatabaseConnection $connection
+     *
+     * @return bool
+     */
+    public abstract function validateConnection (DatabaseConnection $connection);
+
+
+    /**
+     * Retrieves the config value by key
+     *
+     * @param string $key
+     *
+     * @return mixed|null
+     */
+    protected function getConfigValue ($key)
+    {
+        if (!isset($this->config[$key]))
+        {
+            return null;
+        }
+
+        return $this->config[$key];
+    }
+}

--- a/Service/DatabaseConfigurationService.php
+++ b/Service/DatabaseConfigurationService.php
@@ -29,17 +29,25 @@ class DatabaseConfigurationService extends ContainerAware
 
 
     /**
+     * @var array
+     */
+    private $dumpServicesConfig;
+
+
+    /**
      * ConfigurationService constructor.
      *
      * @param Registry $doctrine
      * @param string[] $connectionIdentifiers
      * @param string   $backupPath
+     * @param array    $dumpServicesConfig
      */
-    public function __construct (Registry $doctrine, array $connectionIdentifiers, $backupPath)
+    public function __construct (Registry $doctrine, array $connectionIdentifiers, $backupPath, array $dumpServicesConfig)
     {
         $this->doctrine              = $doctrine;
         $this->connectionIdentifiers = $connectionIdentifiers;
         $this->backupPath            = !empty($backupPath) ? $backupPath : '';
+        $this->dumpServicesConfig    = $dumpServicesConfig;
     }
 
 
@@ -146,5 +154,23 @@ class DatabaseConfigurationService extends ContainerAware
         }
 
         return $this->backupPath;
+    }
+
+
+    /**
+     * Returns the configuration options for the given DatabaseDumpService identifier
+     *
+     * @param string $identifier
+     *
+     * @return array
+     */
+    public function getDumpServiceConfiguration ($identifier)
+    {
+        if (!isset($this->dumpServicesConfig[$identifier]))
+        {
+            return [];
+        }
+
+        return $this->dumpServicesConfig[$identifier];
     }
 }

--- a/Service/DatabaseDumpService.php
+++ b/Service/DatabaseDumpService.php
@@ -1,0 +1,72 @@
+<?php
+
+
+namespace Becklyn\DatabaseDumpBundle\Service;
+
+
+use Becklyn\DatabaseDumpBundle\Entity\DatabaseConnection;
+use Becklyn\DatabaseDumpBundle\Exception\InvalidConnectionTypeException;
+
+class DatabaseDumpService
+{
+    /**
+     * @var BaseDatabaseDumpService[]
+     */
+    private $databaseDumper;
+
+
+    /**
+     * Registers the given DatabaseDumpService as available for use
+     *
+     * @param BaseDatabaseDumpService $databaseDumper
+     */
+    public function addDatabaseDumper (BaseDatabaseDumpService $databaseDumper)
+    {
+        $this->databaseDumper[] = $databaseDumper;
+    }
+
+
+    /**
+     * Backups the given DatabaseConnection.
+     *
+     * Iterates through all registered DatabaseDumpServices and uses the first
+     * that indicates it can handle the given DatabaseConnection's database type.
+     *
+     * @param DatabaseConnection $databaseConnection
+     *
+     * @return array <string> An associative array containing a 'success' (bool) and 'error' (string) key
+     *               that contain additional information whether the dump process succeeded
+     *
+     * @throws InvalidConnectionTypeException
+     */
+    public function dump (DatabaseConnection $databaseConnection)
+    {
+        foreach ($this->databaseDumper as $databaseDumper)
+        {
+            if ($databaseDumper->canHandle($databaseConnection))
+            {
+                return $databaseDumper->dump($databaseConnection);
+            }
+        }
+
+        throw new InvalidConnectionTypeException("Couldn't find a DatabaseDumpService that can handle {$databaseConnection->getType()} databases.");
+    }
+
+
+    /**
+     * Configures the backup path for the given DatabaseConnection
+     *
+     * @param DatabaseConnection $databaseConnection
+     * @param string             $backupPath
+     */
+    public function configureBackupPath (DatabaseConnection $databaseConnection, $backupPath)
+    {
+        foreach ($this->databaseDumper as $databaseDumper)
+        {
+            if ($databaseDumper->canHandle($databaseConnection))
+            {
+                $databaseDumper->configureBackupPath($databaseConnection, $backupPath);
+            }
+        }
+    }
+}

--- a/Service/DatabaseDumpService.php
+++ b/Service/DatabaseDumpService.php
@@ -5,6 +5,7 @@ namespace Becklyn\DatabaseDumpBundle\Service;
 
 
 use Becklyn\DatabaseDumpBundle\Entity\DatabaseConnection;
+use Becklyn\DatabaseDumpBundle\Exception\NoDatabaseDumpersRegisteredException;
 use Becklyn\DatabaseDumpBundle\Exception\InvalidConnectionTypeException;
 
 class DatabaseDumpService
@@ -38,9 +39,15 @@ class DatabaseDumpService
      *               that contain additional information whether the dump process succeeded
      *
      * @throws InvalidConnectionTypeException
+     * @throws NoDatabaseDumpersRegisteredException
      */
     public function dump (DatabaseConnection $databaseConnection)
     {
+        if (is_null($this->databaseDumper))
+        {
+            throw new NoDatabaseDumpersRegisteredException('Unable to execute dump() because there are no BaseDatabaseDumpServices registered.');
+        }
+
         foreach ($this->databaseDumper as $databaseDumper)
         {
             if ($databaseDumper->canHandle($databaseConnection))
@@ -58,9 +65,16 @@ class DatabaseDumpService
      *
      * @param DatabaseConnection $databaseConnection
      * @param string             $backupPath
+     *
+     * @throws NoDatabaseDumpersRegisteredException
      */
     public function configureBackupPath (DatabaseConnection $databaseConnection, $backupPath)
     {
+        if (is_null($this->databaseDumper))
+        {
+            throw new NoDatabaseDumpersRegisteredException('Unable to execute configureBackupPath() because there are no BaseDatabaseDumpServices registered.');
+        }
+
         foreach ($this->databaseDumper as $databaseDumper)
         {
             if ($databaseDumper->canHandle($databaseConnection))

--- a/Service/DatabaseDumpServiceCompilerPass.php
+++ b/Service/DatabaseDumpServiceCompilerPass.php
@@ -1,0 +1,43 @@
+<?php
+
+
+namespace Becklyn\DatabaseDUmpBundle\Service;
+
+
+use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Reference;
+
+class DatabaseDumpServiceCompilerPass implements CompilerPassInterface
+{
+    const DATABASE_DUMPER_SERVICE_KEY = 'becklyn.db_dump.dump';
+
+
+    /**
+     * Scans all registered services for tagged DatabaseDumpServiceInterface implementations
+     * and registers them with the DatabaseDumpService
+     *
+     * @param ContainerBuilder $container
+     */
+    public function process(ContainerBuilder $container)
+    {
+        if (!$container->has(self::DATABASE_DUMPER_SERVICE_KEY))
+        {
+            return;
+        }
+
+        // Get the definition of the DatabaseDumpService service itself
+        $definition = $container->findDefinition(self::DATABASE_DUMPER_SERVICE_KEY);
+
+        // Get all DatabaseDumpServiceInterface implementations that are tagged for the DatabaseDumpService
+        foreach ($container->findTaggedServiceIds(self::DATABASE_DUMPER_SERVICE_KEY) as $serviceKey => $tags)
+        {
+            $definition->addMethodCall(
+                'addDatabaseDumper',
+                [
+                    new Reference($serviceKey)
+                ]
+            );
+        }
+    }
+}

--- a/Service/MysqlDumpService.php
+++ b/Service/MysqlDumpService.php
@@ -16,8 +16,21 @@ use Symfony\Component\Filesystem\Exception\IOException;
 use Symfony\Component\Filesystem\Filesystem;
 use Symfony\Component\Process\Process;
 
-class MysqlDumpService
+class MysqlDumpService extends BaseDatabaseDumpService
 {
+    /**
+     * Returns a unique identifier for this DatabaseDumpService implementation
+     * which will also be used inside the config.yml to specifically configure
+     * this service
+     *
+     * @return string
+     */
+    public function getIdentifier ()
+    {
+        return 'becklyn_mysql';
+    }
+
+
     /**
      * Performs the actual backup operation for the given MySQL DatabaseConnection
      *
@@ -38,9 +51,9 @@ class MysqlDumpService
             throw new NullConnectionException("The connection can't be null.");
         }
 
-        if ($connection->getType() !== DatabaseConnection::TYPE_MYSQL)
+        if (!$this->canHandle($connection))
         {
-            throw new InvalidConnectionTypeException("Can't perform backup on non-MySQL Databases.");
+            throw new InvalidConnectionTypeException("Can't perform backup on non-MySQL/MariaDB Databases.");
         }
 
         if (!$this->validateConnection($connection))
@@ -53,16 +66,8 @@ class MysqlDumpService
             throw new DirectoryCreationException("Permission denied. Could not create directory {$connection->getBackupPath()}");
         }
 
-        $process = new Process(sprintf(
-            'mysqldump --user="%s" --password="%s" --host="%s" --lock-all-tables "%s" | gzip > "%s"',
-            $connection->getUsername(),
-            $connection->getPassword(),
-            $connection->getHost(),
-            $connection->getDatabase(),
-            $connection->getBackupPath()
-        ));
+        $process = new Process($this->getBackupCommand($connection));
         $process->run();
-
 
         // We need to determine ourselves whether mysqldump has raised an error
         // as its return code is unreliable due to the fact that it's always returning 0
@@ -79,6 +84,69 @@ class MysqlDumpService
             'success' => $success,
             'error'   => $errorOut
         ];
+    }
+
+
+    /**
+     * Creates the executing command based on the current configuration
+     * for the given DatabaseConnection
+     *
+     * @param DatabaseConnection $connection
+     *
+     * @return string
+     */
+    protected function getBackupCommand (DatabaseConnection $connection)
+    {
+        $command = sprintf(
+            'mysqldump --user="%s" --password="%s" --host="%s" --lock-all-tables "%s"',
+            $connection->getUsername(),
+            $connection->getPassword(),
+            $connection->getHost(),
+            $connection->getDatabase()
+        );
+
+        // If GZip is enabled we need to pipe it through gzip and change the file extension
+        if ($this->getConfigValue('gzip'))
+        {
+            $command .= sprintf(' | gzip > "%s"', $connection->getBackupPath());
+        }
+        else
+        {
+            $command .= sprintf(' > "%s"', $connection->getBackupPath());
+        }
+
+        return $command;
+    }
+
+
+    /**
+     * Sets or updates, if necessary, the backup file path for the given connection
+     *
+     * @param DatabaseConnection $connection
+     * @param string             $backupPath
+     */
+    public function configureBackupPath (DatabaseConnection $connection, $backupPath)
+    {
+        // Append the .gz file extension if GZip is enabled
+        if ($this->getConfigValue('gzip'))
+        {
+            $backupPath .= '.gz';
+        }
+
+        $connection->setBackupPath($backupPath);
+    }
+
+
+    /**
+     * Determines whether or not this DatabaseDumpService can backup the given DatabaseConnection
+     *
+     * @param DatabaseConnection $connection
+     *
+     * @return bool
+     */
+    public function canHandle (DatabaseConnection $connection)
+    {
+        return ($connection->getType() === DatabaseConnection::TYPE_MYSQL);
     }
 
 

--- a/Service/MysqlDumpService.php
+++ b/Service/MysqlDumpService.php
@@ -170,6 +170,12 @@ class MysqlDumpService extends BaseDatabaseDumpService
      */
     public function validateConnection (DatabaseConnection $connection)
     {
+        // Filter out all connections that we can't handle
+        if (!$this->canHandle($connection))
+        {
+            return false;
+        }
+
         try
         {
             $driver = new mysqli_driver();

--- a/Service/MysqlDumpService.php
+++ b/Service/MysqlDumpService.php
@@ -19,6 +19,12 @@ use Symfony\Component\Process\Process;
 class MysqlDumpService extends BaseDatabaseDumpService
 {
     /**
+     * Identifies the GZip config key
+     */
+    const OPTION_GZIP = 'gzip';
+
+
+    /**
      * Determines whether or not usage of GZip is by default enabled when explicit Dumper configuration is missing
      */
     const OPTION_DEFAULT_GZIP = true;
@@ -111,7 +117,7 @@ class MysqlDumpService extends BaseDatabaseDumpService
         );
 
         // If GZip is enabled we need to pipe it through gzip and change the file extension
-        if ($this->getConfigValue('gzip', self::OPTION_DEFAULT_GZIP))
+        if ($this->getConfigValue(self::OPTION_GZIP, self::OPTION_DEFAULT_GZIP))
         {
             $command .= sprintf(' | gzip > "%s"', $connection->getBackupPath());
         }
@@ -133,7 +139,7 @@ class MysqlDumpService extends BaseDatabaseDumpService
     public function configureBackupPath (DatabaseConnection $connection, $backupPath)
     {
         // Append the .gz file extension if GZip is enabled
-        if ($this->getConfigValue('gzip', self::OPTION_DEFAULT_GZIP))
+        if ($this->getConfigValue(self::OPTION_GZIP, self::OPTION_DEFAULT_GZIP))
         {
             $backupPath .= '.gz';
         }

--- a/Service/MysqlDumpService.php
+++ b/Service/MysqlDumpService.php
@@ -19,6 +19,11 @@ use Symfony\Component\Process\Process;
 class MysqlDumpService extends BaseDatabaseDumpService
 {
     /**
+     * Determines whether or not usage of GZip is by default enabled when explicit Dumper configuration is missing
+     */
+    const OPTION_DEFAULT_GZIP = true;
+
+    /**
      * Returns a unique identifier for this DatabaseDumpService implementation
      * which will also be used inside the config.yml to specifically configure
      * this service
@@ -106,7 +111,7 @@ class MysqlDumpService extends BaseDatabaseDumpService
         );
 
         // If GZip is enabled we need to pipe it through gzip and change the file extension
-        if ($this->getConfigValue('gzip'))
+        if ($this->getConfigValue('gzip', self::OPTION_DEFAULT_GZIP))
         {
             $command .= sprintf(' | gzip > "%s"', $connection->getBackupPath());
         }
@@ -128,7 +133,7 @@ class MysqlDumpService extends BaseDatabaseDumpService
     public function configureBackupPath (DatabaseConnection $connection, $backupPath)
     {
         // Append the .gz file extension if GZip is enabled
-        if ($this->getConfigValue('gzip'))
+        if ($this->getConfigValue('gzip', self::OPTION_DEFAULT_GZIP))
         {
             $backupPath .= '.gz';
         }


### PR DESCRIPTION
### Issues:

This PR addresses #4  and #5.
### New generic DatabaseDumpService

Added a generic DatabaseDumpService which gets all registered BaseDatabaseDumpService implementations injected that are tagged with `becklyn.db_dump.dump` to handle different database types.
### Individual database service configuration

Extended bundle configuration to configure individual database dumper services, which was also the reason why #5 is included in this PR due to some architectural changes.

In order to enable GZip compression for the Becklyn MysqlDatabaseDumpService you need to add the following config value into your `config.yml`:

``` yml
becklyn_database_dump:
    connections:
        # ....
    dumper:
        becklyn_mysql:
            gzip: true
```

The key `becklyn_mysql` used here is the same key that `MysqlDumpService::getIdentifier();` is returning. The values itself can be arbitrary so we keep maximum flexibility for future database adapters, as long as Symfony is able to parse it.
### MysqlDumpService service definition

Another important aspect of this PR is that the `MysqlDumpService` service definition has been removed from this bundle so the user can roll their own implementation.

If you decide that you want to use the reference implementation then all you need to do is add a new service definition for it, which may look like this:

``` yaml
    becklyn.db_dump.mysql_dump:
        class: Becklyn\DatabaseDumpBundle\Service\MysqlDumpService
        arguments:
            - @becklyn.db_dump.configuration
        tags:
            - { name: becklyn.db_dump.dump }
```
